### PR TITLE
Provisioning the vm results in empty sudoer file

### DIFF
--- a/infra/roles/common/tasks/main.yml
+++ b/infra/roles/common/tasks/main.yml
@@ -36,7 +36,7 @@
     copy: src=ssh_keys.pub dest=/home/{{user}}/.ssh/authorized_keys mode=0700 owner={{user}} group={{user}}
 
   - name: Set {{user}} as sudoer
-    lineinfile: "dest=/etc/sudoers state=present line='{{user}} ALL=(ALL) NOPASSWD : ALL'"
+    lineinfile: "dest=/etc/sudoers line='{{user}} ALL=(ALL) NOPASSWD : ALL'"
 
   - name: Remove ubuntu's user
     user: name=ubuntu state=absent remove=yes

--- a/infra/roles/common/tasks/main.yml
+++ b/infra/roles/common/tasks/main.yml
@@ -36,7 +36,7 @@
     copy: src=ssh_keys.pub dest=/home/{{user}}/.ssh/authorized_keys mode=0700 owner={{user}} group={{user}}
 
   - name: Set {{user}} as sudoer
-    lineinfile: dest=/etc/sudoers line="{{user}} ALL=(ALL) NOPASSWD ":" ALL"
+    lineinfile: "dest=/etc/sudoers state=present line='{{user}} ALL=(ALL) NOPASSWD : ALL'"
 
   - name: Remove ubuntu's user
     user: name=ubuntu state=absent remove=yes


### PR DESCRIPTION
On ansible 2.0.0.2 / Mac the original line caused the sudoers file to be empty after the task was executed. 

This change is based on the [ansible documentation for the linein feature](http://docs.ansible.com/ansible/lineinfile_module.html#examples). 
