### PR TITLE
Change the location and permissions of the shared folder

### DIFF
--- a/infra/Vagrantfile.vb
+++ b/infra/Vagrantfile.vb
@@ -17,6 +17,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     fruity.vm.hostname = "fruity-vb"
     fruity.vm.network "private_network", ip: "33.33.33.55" # VirtualBox version
 
+    fruity.vm.synced_folder ".", "/vagrant", disabled: true
+    fruity.vm.synced_folder "../data", "/vagrant", create: true, mount_options: ["dmode=777","fmode=777"]
+
     fruity.vm.provision "ansible" do |ansible|
       ansible.playbook = "playbook.yml"
       ansible.inventory_path = "inventory.ini"

--- a/infra/roles/fruity/tasks/main.yml
+++ b/infra/roles/fruity/tasks/main.yml
@@ -160,3 +160,6 @@
       - "{{nrf}}"
       - "{{downloads}}"
       - "{{home}}/.bash"
+
+  - name: Create symlink to shared folder in home
+    file: src={{vagrantShare}} dest={{shared}} owner={{user}} group={{user}} state=link

--- a/infra/roles/fruity/vars/main.yml
+++ b/infra/roles/fruity/vars/main.yml
@@ -1,12 +1,14 @@
 ---
 user: deploy
 home: "/home/{{user}}"
+shared: "{{home}}/shared"
 nrf: "{{home}}/nrf"
 nrf_sdk_9_0: "{{nrf}}/sdk/nrf_sdk_9_0"
 nrf52_sdk_9_0: "{{nrf}}/sdk/nrf52_sdk_0_9_1"
 downloads: "{{home}}/downloads"
 nrf51_sdk: nRF51_SDK_9.0.0_2e23562.zip
 nrf52_sdk: nRF52_SDK_0.9.2_dbc28c9.zip
+vagrantShare: "/vagrant"
 
 toolchain_version: 20150609
 toolchain_base: gcc-arm-none-eabi-4_9-2015q2


### PR DESCRIPTION
By default vagrant shares the folder in which the machine was created.

In this case the 'infra' folder. This means that all the configuration data and ansible scripts are shared, which causes unnecessary clutter. 

This commit changes the shared folder to the ../data folder. It also changes the permissions to +rwx for all users, since changing the owner of the shared folder doesn't seem to work. (IMHO the security implications are minor, since it is a local, virtual machine)

Lastly as a mostly cosmetic issue, it creates a link called 'shared' in the deploy users home directory and links this with the shared folder.
